### PR TITLE
WIP: SpEL injection and "index-based" injection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+#Eclipse
+.classpath
+.project
+test-output
+.settings
+
+#IntelliJ
+*.iml
+*.ipr
+*.iws
+.idea/
+
+#Gradle
+.gradle
+
+#Build directories
+bin/
+build/
+target/

--- a/README.md
+++ b/README.md
@@ -5,6 +5,12 @@ For more information, please refer to the whitepaper at http://blog.portswigger.
 
 The code can be found at https://github.com/portswigger/backslash-powered-scanner Contributions and feature requests are welcome.
 
+# Building the extension
+
+```
+$ gradle fatJar
+```
+
 # Changelog
 **1.01 20180509**
  - Add 'COM1' Windows reserved filename to magic value attacks

--- a/src/burp/Attack.java
+++ b/src/burp/Attack.java
@@ -27,7 +27,7 @@ class Attack {
 
     private IHttpRequestResponse lastRequest;
 
-    private final String[] keys = {"</html>", "error", "exception", "invalid", "warning", "stack", "sql syntax", "divisor", "divide", "ora-", "division", "infinity", "<script", "<div"};
+    private final String[] keys = {"</html>", "error", "exception", "invalid", "warning", "stack", "sql syntax", "divisor", "divide", "by zero", "ora-", "division", "infinity", "<script", "<div"};
     String payload;
     private Probe probe;
     private String anchor;

--- a/src/burp/DiffingScan.java
+++ b/src/burp/DiffingScan.java
@@ -22,6 +22,8 @@ class DiffingScan {
 
         functions.add(new String[]{"JavaScript injection", "isFinite(1)", "isFinitd(1)", "isFinitee(1)"});
         functions.add(new String[]{"Shell injection", "$((10/10))", "$((10/00))", "$((1/0))"});
+        functions.add(new String[]{"SpEL injection", "${10-1}", "${10/0}", "${10/00}"});
+        functions.add(new String[]{"Expression in index", "[10/10]", "[10/00]", "[1/0]"});
         functions.add(new String[]{"Basic function injection", "abs(1)", "abz(1)", "abf(1)"});
 
         if (!useRandomAnchor) {
@@ -324,6 +326,7 @@ class DiffingScan {
             /* this is the simplest payload set and could be used as a template */
 
             // if the input X looks like a number
+            boolean hasTestedDividedByZero = false;
             if (StringUtils.isNumeric(baseValue)) {
 
                 // compare the results of appending /0 and /1
@@ -344,7 +347,11 @@ class DiffingScan {
 
                     // if *that* worked, try injecting a function call
                     results.addAll(exploreAvailableFunctions(injector, softBase, "/", "", false));
+                    hasTestedDividedByZero = true;
                 }
+            }
+            if(!hasTestedDividedByZero && Utilities.globalSettings.getBoolean("thorough mode")) { //Test division by zero even for value that are not numeric
+                results.addAll(exploreAvailableFunctions(injector, softBase, "", "", false));
             }
 
             if (Utilities.mightBeOrderBy(insertionPoint.getInsertionPointName(), baseValue)) {

--- a/src/burp/PayloadInjector.java
+++ b/src/burp/PayloadInjector.java
@@ -84,6 +84,7 @@ class PayloadInjector {
 
 
     private Attack buildAttackFromProbe(Probe probe, String payload) {
+        if(payload == null) payload=""; //Null safe
         boolean randomAnchor = probe.getRandomAnchor();
         byte prefix = probe.getPrefix();
 
@@ -123,7 +124,7 @@ class PayloadInjector {
         byte[] request = insertionPoint.buildRequest(payload.getBytes());
 
         if (needCacheBuster) {
-            IParameter cacheBuster = burp.Utilities.helpers.buildParameter(Utilities.generateCanary(), "1", IParameter.PARAM_URL);
+            IParameter cacheBuster = burp.Utilities.helpers.buildParameter(Utilities.generateCanary(), "1", IParameter.PARAM_BODY);
             request = burp.Utilities.helpers.addParameter(request, cacheBuster);
         }
 

--- a/src/burp/PayloadInjector.java
+++ b/src/burp/PayloadInjector.java
@@ -124,7 +124,7 @@ class PayloadInjector {
         byte[] request = insertionPoint.buildRequest(payload.getBytes());
 
         if (needCacheBuster) {
-            IParameter cacheBuster = burp.Utilities.helpers.buildParameter(Utilities.generateCanary(), "1", IParameter.PARAM_BODY);
+            IParameter cacheBuster = burp.Utilities.helpers.buildParameter(Utilities.generateCanary(), "1", IParameter.PARAM_URL);
             request = burp.Utilities.helpers.addParameter(request, cacheBuster);
         }
 


### PR DESCRIPTION
This pull request include the following new patterns to the diff scan:

 - `param=1234` => `param=1234${10/0}`
 - `param=1234` => `param[10/0]=1234`

The second one will cover specifically this vulnerability: http://gosecure.net/2018/05/15/beware-of-the-magic-spell-part-1-cve-2018-1273/
But it might found glitches with other frameworks.

## URL encoding issue

⚠️  Do not integrate this PR. There is still one major issue.

The current problem I have that with the [SpEL payloads](https://github.com/PortSwigger/backslash-powered-scanner/pull/12/commits/381ec25942e299385a711bf2961b7c62e27d1233#diff-5acb07bdbee602734ba603c65d460331R25) is that curly brackets are not properly handled.

 - When I use the value `"${10-1}"`, curly bracket are not URL encoded (Expected: `"%24%7b 10-1 %7d"`)
 - When I use `"%7b"`, Burp will encode it to `"%257b"`. It's a catch-22. 😄

I did my tests on Tomcat and curly brackets need to be encoded otherwise a 400 is returned.

This does not appears to be specific to the Backslash scanner. My quick analysis pointed to [Helper.buildParameter()](https://github.com/GoSecure/backslash-powered-scanner/blob/acc63be9ad5e92a46d873ec97ac91ec02819875b/src/burp/PayloadInjector.java#L127) which could be responsible for it.

This encoding problem is maybe affecting the other tests from this plugin that use `{ }`.