### PR TITLE
fixed php injection bug

### DIFF
--- a/src/burp/DiffingScan.java
+++ b/src/burp/DiffingScan.java
@@ -41,7 +41,7 @@ class DiffingScan extends ParamScan {
         functions.add(new String[]{"SQL Server injection", "power(current_request_id(),0)", "power(current_request_ids(),0)", "power(current_request_ic(),0)"});
         functions.add(new String[]{"PostgreSQL injection", "power(inet_server_port(),0)", "power(inet_server_por(),0)", "power(inet_server_pont(),0)"});
         functions.add(new String[]{"SQLite injection", "min(sqlite_version(),1)", "min(sqlite_versionn(),1)", "min(sqlite_versipn(),1)"});
-        functions.add(new String[]{"PHP injection", "pow(phpversion(),0)", "pow(phpversionn(),0)", "pow(phpversiom(),0)"});
+        functions.add(new String[]{"PHP injection", "pow((int)phpversion(),0)", "pow((int)phpversionn(),0)", "pow((int)phpversiom(),0)"});
         functions.add(new String[]{"Perl injection", "(getppid()**0)", "(getppidd()**0)", "(getppif()**0)"});
 
 


### PR DESCRIPTION
Since `phpversion()` can return, for example, `8.4.4` instead of `8,4`, and `8.4.4` is not a valid numeric format in PHP, this would result in a false negative given that even a correct probe would fail.